### PR TITLE
Update project files and packet versions

### DIFF
--- a/Demo.Client/Demo.Client.csproj
+++ b/Demo.Client/Demo.Client.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Demo.Contracts/Demo.Contracts.csproj
+++ b/Demo.Contracts/Demo.Contracts.csproj
@@ -1,8 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Demo.Server/Demo.Server.csproj
+++ b/Demo.Server/Demo.Server.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <TargetFrameworks>netcoreapp2.1;net6.0</TargetFrameworks>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Horizon.XmlRpc.AspNetCore/Horizon.XmlRpc.AspNetCore.csproj
+++ b/Horizon.XmlRpc.AspNetCore/Horizon.XmlRpc.AspNetCore.csproj
@@ -10,12 +10,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
-    <PackageVersion>2.5.0</PackageVersion>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+    <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
     <PackageProjectUrl>https://github.com/Horizon0156/XmlRpc</PackageProjectUrl>
     <Description>ASP.NET Core integration for hosting XmlRpc Services. </Description>
-    <PackOnBuild>true</PackOnBuild>
     <PackageId>Horizon.XmlRpc.AspNetCore</PackageId>
   </PropertyGroup>
 

--- a/Horizon.XmlRpc.Client/Horizon.XmlRpc.Client.csproj
+++ b/Horizon.XmlRpc.Client/Horizon.XmlRpc.Client.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
-    <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.5.0</PackageVersion>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+    <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
     <PackageProjectUrl>https://github.com/Horizon0156/XmlRpc</PackageProjectUrl>
     <Description>XmlRpcProxyGen port of Charles Cook's XML-RPC library to .NET Standard / .NET Core. </Description>
@@ -14,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Horizon.XmlRpc.Client/Horizon.XmlRpc.Client.csproj
+++ b/Horizon.XmlRpc.Client/Horizon.XmlRpc.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <ReleaseVersion>2.5.2</ReleaseVersion>
     <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
@@ -10,6 +10,11 @@
     <PackageId>Horizon.XmlRpc.Client</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />

--- a/Horizon.XmlRpc.Client/XmlRpcAsyncResult.cs
+++ b/Horizon.XmlRpc.Client/XmlRpcAsyncResult.cs
@@ -39,7 +39,7 @@ namespace Horizon.XmlRpc.Client
 
         public bool IsCompleted
         {
-            get { return isCompleted; }
+            get { return response.IsCompleted; }
         }
 
         public bool UseEmptyParamsTag
@@ -170,7 +170,6 @@ namespace Horizon.XmlRpc.Client
         XmlRpcClientProtocol clientProtocol;
         object userAsyncState;
         bool completedSynchronously;
-        bool isCompleted;
         bool endSendCalled = false;
         ManualResetEvent manualResetEvent;
         Exception exception;

--- a/Horizon.XmlRpc.Core/Horizon.XmlRpc.Core.csproj
+++ b/Horizon.XmlRpc.Core/Horizon.XmlRpc.Core.csproj
@@ -2,16 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
-    <PackageVersion>2.5.0</PackageVersion>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+    <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
     <PackageProjectUrl>https://github.com/Horizon0156/XmlRpc</PackageProjectUrl>
     <Description>Port of Charles Cook's XML-RPC library to .NET Standard / .NET Core</Description>
-    <PackOnBuild>true</PackOnBuild>
     <PackageId>Horizon.XmlRpc.Core</PackageId>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
-  </ItemGroup>
 </Project>

--- a/Horizon.XmlRpc.Core/Horizon.XmlRpc.Core.csproj
+++ b/Horizon.XmlRpc.Core/Horizon.XmlRpc.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <ReleaseVersion>2.5.2</ReleaseVersion>
     <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
@@ -9,4 +9,10 @@
     <Description>Port of Charles Cook's XML-RPC library to .NET Standard / .NET Core</Description>
     <PackageId>Horizon.XmlRpc.Core</PackageId>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
+  </PropertyGroup>
+  
 </Project>

--- a/Horizon.XmlRpc.Server/Horizon.XmlRpc.Server.csproj
+++ b/Horizon.XmlRpc.Server/Horizon.XmlRpc.Server.csproj
@@ -1,13 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <ReleaseVersion>2.5.2</ReleaseVersion>
     <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
     <PackageProjectUrl>https://github.com/Horizon0156/XmlRpc</PackageProjectUrl>
     <Description>XmlRpcListenerService port of Charles Cook's XML-RPC library to .NET Standard / .NET Core. </Description>
     <PackageId>Horizon.XmlRpc.Server</PackageId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>5.0</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Horizon.XmlRpc.Server/Horizon.XmlRpc.Server.csproj
+++ b/Horizon.XmlRpc.Server/Horizon.XmlRpc.Server.csproj
@@ -2,20 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
-    <PackageVersion>2.5.0</PackageVersion>
+    <ReleaseVersion>2.5.2</ReleaseVersion>
+    <PackageVersion>2.5.2</PackageVersion>
     <Authors>Horizon0156</Authors>
     <PackageProjectUrl>https://github.com/Horizon0156/XmlRpc</PackageProjectUrl>
     <Description>XmlRpcListenerService port of Charles Cook's XML-RPC library to .NET Standard / .NET Core. </Description>
-    <PackOnBuild>true</PackOnBuild>
     <PackageId>Horizon.XmlRpc.Server</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Horizon.XmlRpc.Core\Horizon.XmlRpc.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/Horizon.XmlRpc.Server/XmlRpcServerProtocol.cs
+++ b/Horizon.XmlRpc.Server/XmlRpcServerProtocol.cs
@@ -73,7 +73,7 @@ namespace Horizon.XmlRpc.Server
             {
                 if (ex.InnerException != null)
                     throw ex.InnerException;
-                throw ex;
+                throw;
             }
             XmlRpcResponse response = new XmlRpcResponse(reto);
             return response;


### PR DESCRIPTION
This commits enables modern NET Analyzers and fixes warnings that I get after that. Right now It uses .NET5 platform because this is minimal version that support modern analyzers: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview?tabs=net-7
This commit adds conditional variant so there will be two versions: .NET5 and NET Standard 2.0. Technically EnableNETAnalyzers can be set to true even when there is no suitable target framework, I do not explore all possibilities.

I tested both sync and async methods and both work for me.

Anyway, I can successfully pack projects into nuget packages. I set version to 2.5.2.