### PR TITLE
Fix anchor link

### DIFF
--- a/Horizon.XmlRpc.Server/XmlRpcDocWriter.cs
+++ b/Horizon.XmlRpc.Server/XmlRpcDocWriter.cs
@@ -130,7 +130,7 @@ namespace Horizon.XmlRpc.Server
 
             wrtr.WriteStartElement("h2");
             wrtr.WriteStartElement("a");
-            wrtr.WriteAttributeString("name", "#" + mthdInfo.XmlRpcName);
+            wrtr.WriteAttributeString("name", mthdInfo.XmlRpcName);
             wrtr.WriteString("method " + mthdInfo.XmlRpcName);
             wrtr.WriteEndElement();
             wrtr.WriteEndElement();


### PR DESCRIPTION
Anchor name should not have a `#` prefix:
https://www.w3.org/TR/html401/struct/links.html#h-12.2.1